### PR TITLE
Enhancement: Multiple Camouflage blocks

### DIFF
--- a/src/main/java/dev/su5ed/mffs/blockentity/ProjectorBlockEntity.java
+++ b/src/main/java/dev/su5ed/mffs/blockentity/ProjectorBlockEntity.java
@@ -465,7 +465,9 @@ public class ProjectorBlockEntity extends ModularBlockEntity implements Projecto
                     return block;
                 }
             }
-            List<Block> weightedList = this.checkNeighbors().entrySet()
+            var neighborsInventory = this.checkNeighbors();
+            if(neighborsInventory.isEmpty()) return null;
+            List<Block> weightedList =neighborsInventory.entrySet()
                     .stream()
                     // For each entry: create a list that repeats the block as many times as its weight
                     .flatMap(e -> Collections.nCopies(e.getValue(), e.getKey()).stream())


### PR DESCRIPTION
Camouflage blocks are now sourced from neighboring inventories instead of the Projector, therefore the Matrix inventory is no longer filled 

This change allows blocks to be selected based on the contents of adjacent inventories, 
making camouflage behavior more dynamic and weighted by actual block counts.

<img width="1465" height="1243" alt="grafik" src="https://github.com/user-attachments/assets/ab1d92df-5c97-4d75-817d-32bb203a64c2" />
<img width="1401" height="619" alt="grafik" src="https://github.com/user-attachments/assets/d735b033-681f-498e-8b14-ec3c5f2ad587" />
<img width="2284" height="1192" alt="grafik" src="https://github.com/user-attachments/assets/9841c6d6-37ea-41aa-bc90-57a6a47449ef" />

