### PR TITLE
Fix module de-duplication bug in fortron cost calculation

### DIFF
--- a/src/main/java/dev/su5ed/mffs/blockentity/ModularBlockEntity.java
+++ b/src/main/java/dev/su5ed/mffs/blockentity/ModularBlockEntity.java
@@ -146,7 +146,8 @@ public abstract class ModularBlockEntity extends FortronBlockEntity implements M
     }
 
     protected int doGetFortronCost() {
-        double cost = StreamEx.of(getModuleStacks())
+        double cost = getAllModuleItemsStream()
+                .filter(ModUtil::isModule)
             .mapToDouble(stack -> stack.getCount() * Optional.ofNullable(stack.getCapability(ModCapabilities.MODULE_TYPE))
                 .map(module -> (double) module.getFortronCost(getAmplifier()))
                 .orElse(0.0))


### PR DESCRIPTION
Part 1 fix for #93 "Fortron Capacitor transmission rate incorrect."

This fixes the module math problem in directional slots. Will stop the multiple of 5 issue.