### PR TITLE
Fix capacitor transfer rate display multiplier

### DIFF
--- a/src/main/java/dev/su5ed/mffs/screen/FortronCapacitorScreen.java
+++ b/src/main/java/dev/su5ed/mffs/screen/FortronCapacitorScreen.java
@@ -43,7 +43,7 @@ public class FortronCapacitorScreen extends FortronScreen<FortronCapacitorMenu> 
         poseStack.popMatrix();
 
         guiGraphics.drawString(this.font, ModUtil.translate("screen", "linked_devices", this.menu.blockEntity.getDevicesByFrequency().size()), 8, 28, GuiColors.DARK_GREY, false);
-        guiGraphics.drawString(this.font, ModUtil.translate("screen", "transmission_rate", this.menu.blockEntity.getTransmissionRate() * 10), 8, 40, GuiColors.DARK_GREY, false);
+        guiGraphics.drawString(this.font, ModUtil.translate("screen", "transmission_rate", this.menu.blockEntity.getTransmissionRate() * 2), 8, 40, GuiColors.DARK_GREY, false);
         guiGraphics.drawString(this.font, ModUtil.translate("screen", "range", this.menu.blockEntity.getTransmissionRange()), 8, 52, GuiColors.DARK_GREY, false);
 
         guiGraphics.drawString(this.font, ModUtil.translate("screen", "fortron.name"), 8, 95, GuiColors.DARK_GREY, false);


### PR DESCRIPTION
  The Fortron Capacitor GUI was displaying transfer rate with a 10x multiplier,
  while the actual transfer rate (transferring every 10 ticks) should only be
  multiplied by 2 to show per-second rate (20 ticks = 1 second, 10 ticks = 0.5s).

  This caused the GUI to show 5x higher transfer rates than actual, making it
  appear that more speed modules were needed than actually required.

  Changed multiplier from 10 to 2 to correctly display transfer rate in L/s.