### PR TITLE
Fix module de-duplication bug in fortron cost calculation

### DIFF
--- a/src/main/java/dev/su5ed/mffs/blockentity/ModularBlockEntity.java
+++ b/src/main/java/dev/su5ed/mffs/blockentity/ModularBlockEntity.java
@@ -146,7 +146,8 @@ public abstract class ModularBlockEntity extends FortronBlockEntity implements M
     }
 
     protected int doGetFortronCost() {
-        double cost = StreamEx.of(getModuleStacks())
+        double cost = getAllModuleItemsStream()
+                .filter(ModUtil::isModule)
             .mapToDouble(stack -> stack.getCount() * Optional.ofNullable(stack.getCapability(ModCapabilities.MODULE_TYPE))
                 .map(module -> (double) module.getFortronCost(getAmplifier()))
                 .orElse(0.0))


### PR DESCRIPTION
The doGetFortronCost() method was using getModuleStacks() which converts the module stream to a Set, causing identical modules in different slots to be duplicated. This resulted in incorrect fortron cost calculations when multiple identical modules were installed in directional slots.

Changed to use getAllModuleItemsStream() directly, which processes each module slot individually without de-duplication.