### PR TITLE
1.21.1 Enhancement: Add configurable force field walk-through and damage options

### DIFF
--- a/src/main/java/dev/su5ed/mffs/MFFSConfig.java
+++ b/src/main/java/dev/su5ed/mffs/MFFSConfig.java
@@ -42,6 +42,10 @@ public class MFFSConfig {
 
         public final ModConfigSpec.IntValue interdictionMatrixKillEnergy;
 
+        public final ModConfigSpec.BooleanValue disableForceFieldDamageForAuthorizedPlayers;
+        public final ModConfigSpec.BooleanValue disableForceFieldEffectsForAuthorizedPlayers;
+        public final ModConfigSpec.BooleanValue allowWalkThroughForceFields;
+
         private Common(ModConfigSpec.Builder builder) {
             builder.push("general");
             this.enableElectricity = builder
@@ -92,6 +96,18 @@ public class MFFSConfig {
             this.interdictionMatrixKillEnergy = builder
                 .comment("Energy to consume when the Interdiction Matrix kills a player")
                 .defineInRange("interdictionMatrixKillEnergy", 0, 0, Integer.MAX_VALUE);
+            builder.pop();
+
+            builder.push("force_field");
+            this.disableForceFieldDamageForAuthorizedPlayers = builder
+                .comment("Prevent authorized players from taking damage when passing through force fields")
+                .define("disableForceFieldDamageForAuthorizedPlayers", false);
+            this.disableForceFieldEffectsForAuthorizedPlayers = builder
+                .comment("Remove confusion and slowness effects for authorized players passing through force fields")
+                .define("disableForceFieldEffectsForAuthorizedPlayers", false);
+            this.allowWalkThroughForceFields = builder
+                .comment("Allow authorized players to walk through force fields without sneaking. WARNING: May cause occasional clipping issues on horizontal platforms.")
+                .define("allowWalkThroughForceFields", false);
             builder.pop();
         }
     }


### PR DESCRIPTION
- Added three new config options in mffs-common.toml [force_field] section:
  - disableForceFieldDamageForAuthorizedPlayers: Prevents authorized players from taking damage when passing through force fields
  - disableForceFieldEffectsForAuthorizedPlayers: Removes confusion and slowness effects for authorized players
  - allowWalkThroughForceFields: Allows authorized players to walk through force fields without sneaking
- Updated ForceFieldBlockImpl collision logic to support walk-through mode while maintaining floor solidity
- Creative players always have full access regardless of config settings
- All options default to false, preserving original behavior