### PR TITLE
Fix: Shock module ignores biometric authorisation

### DIFF
--- a/src/main/java/dev/su5ed/mffs/MFFSConfig.java
+++ b/src/main/java/dev/su5ed/mffs/MFFSConfig.java
@@ -42,7 +42,8 @@ public class MFFSConfig {
 
         public final ModConfigSpec.IntValue interdictionMatrixKillEnergy;
 
-        public final ModConfigSpec.BooleanValue disableForceFieldDamageForAuthorizedPlayers;
+        public final ModConfigSpec.BooleanValue disableForceFieldInstantDeathForAuthorizedPlayers;
+        public final ModConfigSpec.BooleanValue disableShockModuleDamageForAuthorizedPlayers;
         public final ModConfigSpec.BooleanValue disableForceFieldEffectsForAuthorizedPlayers;
         public final ModConfigSpec.BooleanValue allowWalkThroughForceFields;
 
@@ -99,9 +100,12 @@ public class MFFSConfig {
             builder.pop();
 
             builder.push("force_field");
-            this.disableForceFieldDamageForAuthorizedPlayers = builder
-                .comment("Prevent authorized players from taking damage when passing through force fields")
-                .define("disableForceFieldDamageForAuthorizedPlayers", false);
+            this.disableForceFieldInstantDeathForAuthorizedPlayers = builder
+                .comment("Prevent authorized players from taking instant death damage when passing through force fields")
+                .define("disableForceFieldInstantDeathForAuthorizedPlayers", false);
+            this.disableShockModuleDamageForAuthorizedPlayers = builder
+                .comment("Prevent authorized players from taking shock module damage when passing through force fields")
+                .define("disableShockModuleDamageForAuthorizedPlayers", false);
             this.disableForceFieldEffectsForAuthorizedPlayers = builder
                 .comment("Remove confusion and slowness effects for authorized players passing through force fields")
                 .define("disableForceFieldEffectsForAuthorizedPlayers", false);

--- a/src/main/java/dev/su5ed/mffs/block/ForceFieldBlockImpl.java
+++ b/src/main/java/dev/su5ed/mffs/block/ForceFieldBlockImpl.java
@@ -200,15 +200,12 @@ public class ForceFieldBlockImpl extends Block implements ForceFieldBlock, Entit
                         }
                     }
 
-                    // Apply damage
+                    // Apply instant death damage
                     // Creative players never take damage
-                    // Sneaking authorized players don't take damage
-                    // Authorized players in walk-through mode don't take damage
-                    // Authorized players don't take damage if config is enabled
-                    boolean applyDamage = !(entity instanceof Player player) || !player.isCreative() && !isAuthorizedPlayer
-                        || !isSneaking(entity)
-                        && !MFFSConfig.COMMON.allowWalkThroughForceFields.get()
-                        && !MFFSConfig.COMMON.disableForceFieldDamageForAuthorizedPlayers.get();
+                    // If instant death is disabled for authorized players, no one takes instant death
+                    // Otherwise everyone except creative takes instant death
+                    boolean applyDamage = !MFFSConfig.COMMON.disableForceFieldInstantDeathForAuthorizedPlayers.get()
+                        && (!(entity instanceof Player player) || !player.isCreative());
 
                     if (applyDamage) {
                         ModUtil.shockEntity(entity, Integer.MAX_VALUE);

--- a/src/main/java/dev/su5ed/mffs/util/module/ShockModule.java
+++ b/src/main/java/dev/su5ed/mffs/util/module/ShockModule.java
@@ -1,12 +1,20 @@
 package dev.su5ed.mffs.util.module;
 
+import dev.su5ed.mffs.MFFSConfig;
+import dev.su5ed.mffs.api.ForceFieldBlock;
+import dev.su5ed.mffs.api.Projector;
 import dev.su5ed.mffs.api.module.ModuleType;
+import dev.su5ed.mffs.api.security.BiometricIdentifier;
+import dev.su5ed.mffs.api.security.FieldPermission;
 import dev.su5ed.mffs.util.ModUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+
+import java.util.Optional;
 
 public class ShockModule extends BaseModule {
 
@@ -17,7 +25,26 @@ public class ShockModule extends BaseModule {
     @Override
     public boolean onCollideWithForceField(Level level, BlockPos pos, Entity entity) {
         if (entity instanceof LivingEntity living) {
-            ModUtil.shockEntity(living, this.stack.getCount());
+            boolean isAuthorizedPlayer = false;
+            if (entity instanceof Player player && level.getBlockState(pos).getBlock() instanceof ForceFieldBlock ffBlock) {
+                Optional<Projector> projector = ffBlock.getProjector(level, pos);
+                if (projector.isPresent()) {
+                    BiometricIdentifier identifier = projector.get().getBiometricIdentifier();
+                    isAuthorizedPlayer = player.isCreative() || identifier != null && identifier.isAccessGranted(player, FieldPermission.WARP);
+                }
+            }
+
+            // Apply shock module damage when instant death is disabled
+            // Creative players never take damage
+            // Authorized players can disable shock damage with config
+            // Unauthorized players and non-players ALWAYS take shock damage (no config to disable)
+            boolean applyDamage = MFFSConfig.COMMON.disableForceFieldInstantDeathForAuthorizedPlayers.get()
+                && (!(entity instanceof Player player) || !player.isCreative() && (!isAuthorizedPlayer
+                    || !MFFSConfig.COMMON.disableShockModuleDamageForAuthorizedPlayers.get()));
+
+            if (applyDamage) {
+                ModUtil.shockEntity(living, this.stack.getCount());
+            }
         }
         return super.onCollideWithForceField(level, pos, entity);
     }


### PR DESCRIPTION
UPDATE TO #113

  Fixed bug where shock module damaged authorised players despite biometric
  authorisation. Refactored force field damage system to prevent redundant
  damage (instant death + shock simultaneously) and provide granular control.

  Changes:
  - MFFSConfig.java: Split damage config into two separate options:
    - disableForceFieldInstantDeathForAuthorizedPlayers (renamed from disableForceFieldDamageForAuthorizedPlayers)
    - disableShockModuleDamageForAuthorizedPlayers (new)

  - ForceFieldBlockImpl.java: Fixed boolean logic bug where authorised players incorrectly took instant death damage

  - ShockModule.java: Added biometric authorisation checks and config support. Shock damage now only applies when instant death is disabled (acts as alternative damage). Authorised players can disable shock damage via config. Unauthorised players/mobs always take shock damage when instant death disabled.

  Behavior: Instant death and shock damage are now mutually exclusive. When
  instant death is enabled, only instant death applies. When disabled, shock
  module provides alternative damage that authorised players can optionally disable.