### PR TITLE
fix(security): validate SetItemInSlotPacket targets MFFS ghost slots only

### DIFF
--- a/src/main/java/dev/su5ed/mffs/network/SetItemInSlotPacket.java
+++ b/src/main/java/dev/su5ed/mffs/network/SetItemInSlotPacket.java
@@ -1,11 +1,13 @@
 package dev.su5ed.mffs.network;
 
 import dev.su5ed.mffs.MFFSMod;
+import dev.su5ed.mffs.menu.FortronMenu;
+import dev.su5ed.mffs.util.inventory.SlotInventoryFilter;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
@@ -25,9 +27,20 @@ public record SetItemInSlotPacket(int slot, ItemStack stack) implements CustomPa
     }
 
     public void handle(IPayloadContext ctx) {
-        Player player = ctx.player();
-        if (player.containerMenu != null) {
-            player.containerMenu.getSlot(this.slot).set(this.stack);
+        if (ctx.flow().isClientbound()) {
+            return;
         }
+        var player = ctx.player();
+        if (!(player.containerMenu instanceof FortronMenu<?> menu)) {
+            return;
+        }
+        if (this.slot < 0 || this.slot >= menu.slots.size()) {
+            return;
+        }
+        Slot target = menu.getSlot(this.slot);
+        if (!(target instanceof SlotInventoryFilter)) {
+            return;
+        }
+        target.set(this.stack);
     }
 }


### PR DESCRIPTION
## Summary

`SetItemInSlotPacket` (`mffs:set_slot_item`) accepts any slot index and `ItemStack` from the client and writes it into the player's currently open container menu without validation. A modified client can target player inventory slots (e.g. while `InventoryMenu` is open) and inject arbitrary items.

This patch restricts the handler to MFFS ghost filter slots only, matching the legitimate JEI usage in `BasicGhostIngredientHandler`.

## Impact

- **Severity:** Critical
- **Effect:** Arbitrary item give (self) on dedicated servers
- **Affected version:** `mffs-5.4.27.jar` (Minecraft 1.21.1 / NeoForge), used in the **All the Mods 10** modpack

## Legitimate usage

The packet is sent from `BasicGhostIngredientHandler` when dragging JEI ingredients onto `SlotInventoryFilter` slots in MFFS screens (`FortronMenu` subclasses).

## Fix

In `SetItemInSlotPacket.handle()`:

1. Server-side only (`!ctx.flow().isClientbound()`)
2. Require open menu to be a `FortronMenu`
3. Validate `0 <= slot < menu.slots.size()`
4. Require target slot to be a `SlotInventoryFilter`

## Reproduction

1. Join a server with MFFS 5.4.27
2. Send `mffs:set_slot_item` with a player inventory slot index and an arbitrary `ItemStack` while any container is open
3. The item appears in the targeted inventory slot without going through normal give/creative commands