### PR TITLE
fix(projector): resolve ghost force field blocks on explosive destruction (#133)

### DIFF
--- a/src/main/java/dev/su5ed/mffs/blockentity/ForceFieldBlockEntity.java
+++ b/src/main/java/dev/su5ed/mffs/blockentity/ForceFieldBlockEntity.java
@@ -18,9 +18,14 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.network.PacketDistributor;
 
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Optional;
 
-public class ForceFieldBlockEntity extends BlockEntity {
+public class ForceFieldBlockEntity extends BaseBlockEntity {
     private BlockPos projector;
     private BlockState camouflage;
     private int clientBlockLight;
@@ -45,6 +50,28 @@ public class ForceFieldBlockEntity extends BlockEntity {
     public void setCamouflage(BlockState camouflage) {
         this.camouflage = camouflage;
         setChanged();
+    }
+
+    public BlockPos getProjectorPos() {
+        return this.projector;
+    }
+
+    @Nullable
+    @Override
+    public AbstractContainerMenu createMenu(int containerId, Inventory playerInventory, Player player) {
+        return null; // Force field blocks do not possess a GUI/Menu
+    }
+
+    @Override
+    public void tickServer() {
+        super.tickServer();
+
+        // Check once per second if the parent projector still exists
+        if (this.projector != null && (this.level.getGameTime() + this.worldPosition.hashCode()) % 20 == 0) {
+            if (getProjector().isEmpty()) {
+                this.level.removeBlock(this.worldPosition, false);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/dev/su5ed/mffs/blockentity/ForceFieldBlockEntity.java
+++ b/src/main/java/dev/su5ed/mffs/blockentity/ForceFieldBlockEntity.java
@@ -29,6 +29,7 @@ public class ForceFieldBlockEntity extends BaseBlockEntity {
     private BlockPos projector;
     private BlockState camouflage;
     private int clientBlockLight;
+    private static final int CHECK_INTERVAL_TICKS = 20;
 
     public ForceFieldBlockEntity(BlockPos pos, BlockState state) {
         super(ModObjects.FORCE_FIELD_BLOCK_ENTITY.get(), pos, state);
@@ -67,7 +68,7 @@ public class ForceFieldBlockEntity extends BaseBlockEntity {
         super.tickServer();
 
         // Check once per second if the parent projector still exists
-        if (this.projector != null && (this.level.getGameTime() + this.worldPosition.hashCode()) % 20 == 0) {
+        if (this.projector != null && (this.level.getGameTime() + this.worldPosition.hashCode()) % CHECK_INTERVAL_TICKS == 0) {
             if (getProjector().isEmpty()) {
                 this.level.removeBlock(this.worldPosition, false);
             }

--- a/src/main/java/dev/su5ed/mffs/blockentity/ProjectorBlockEntity.java
+++ b/src/main/java/dev/su5ed/mffs/blockentity/ProjectorBlockEntity.java
@@ -59,6 +59,8 @@ public class ProjectorBlockEntity extends ModularBlockEntity implements Projecto
     private static final String ROTATION_ROLL_CACHE_KEY = "getRotationRoll";
     private static final String INTERIOR_POINTS_CACHE_KEY = "getInteriorPoints";
 
+    private static final int CLEANUP_RADIUS = 32;
+
     private final List<ScheduledEvent> scheduledEvents = new ArrayList<>();
     public final InventorySlot secondaryCard;
     public final InventorySlot projectorModeSlot;
@@ -450,7 +452,7 @@ public class ProjectorBlockEntity extends ModularBlockEntity implements Projecto
         }
         // PATH B: Fallback scan executed when explosive destruction wipes inventory and memory
         else {
-            int radius = 32; // Search cube (65x65x65) around the projector
+            int radius = CLEANUP_RADIUS;
 
             BlockPos.betweenClosedStream(
                     this.worldPosition.offset(-radius, -radius, -radius),

--- a/src/main/java/dev/su5ed/mffs/blockentity/ProjectorBlockEntity.java
+++ b/src/main/java/dev/su5ed/mffs/blockentity/ProjectorBlockEntity.java
@@ -146,6 +146,7 @@ public class ProjectorBlockEntity extends ModularBlockEntity implements Projecto
     @Override
     public void setRemoved() {
         if (!this.level.isClientSide) {
+            destroyField();
             NeoForge.EVENT_BUS.unregister(this);
         }
         super.setRemoved();
@@ -425,15 +426,51 @@ public class ProjectorBlockEntity extends ModularBlockEntity implements Projecto
 
     @Override
     public void destroyField() {
-        Collection<TargetPosPair> fieldPositions = getCalculatedFieldPositions();
+        if (this.level == null || this.level.isClientSide()) {
+            return;
+        }
+
+        Set<BlockPos> blocksToRemove = new HashSet<>();
+
+        // 1. Calculate field positions if mode module is present
+        if (getMode().isPresent()) {
+            getCalculatedFieldPositions().forEach(pair -> blocksToRemove.add(pair.pos()));
+        }
+
+        // 2. Include positions stored in local memory
+        if (!this.projectedBlocks.isEmpty()) {
+            blocksToRemove.addAll(this.projectedBlocks);
+        }
+
+        // PATH A: Standard cleanup using cached memory or calculated positions
+        if (!blocksToRemove.isEmpty()) {
+            blocksToRemove.stream()
+                    .filter(pos -> this.level.isLoaded(pos) && this.level.getBlockState(pos).is(ModBlocks.FORCE_FIELD.get()))
+                    .forEach(pos -> this.level.removeBlock(pos, false));
+        }
+        // PATH B: Fallback scan executed when explosive destruction wipes inventory and memory
+        else {
+            int radius = 32; // Search cube (65x65x65) around the projector
+
+            BlockPos.betweenClosedStream(
+                    this.worldPosition.offset(-radius, -radius, -radius),
+                    this.worldPosition.offset(radius, radius, radius)
+            ).forEach(pos -> {
+                if (this.level.isLoaded(pos) && this.level.getBlockState(pos).is(ModBlocks.FORCE_FIELD.get())) {
+                    this.level.getBlockEntity(pos, ModObjects.FORCE_FIELD_BLOCK_ENTITY.get()).ifPresent(be -> {
+                        // Compare BlockPos against BlockPos using getProjectorPos()
+                        if (this.worldPosition.equals(be.getProjectorPos())) {
+                            this.level.removeBlock(pos, false);
+                        }
+                    });
+                }
+            });
+        }
+
         this.projectedBlocks.clear();
         this.projectionCache.invalidateAll();
-        this.semaphore.reset();
-        if (!this.level.isClientSide) {
-            StreamEx.of(fieldPositions)
-                .map(TargetPosPair::pos)
-                .filter(pos -> this.level.getBlockState(pos).is(ModBlocks.FORCE_FIELD.get()))
-                .forEach(pos -> this.level.removeBlock(pos, false));
+        if (this.semaphore != null) {
+            this.semaphore.reset();
         }
     }
 


### PR DESCRIPTION
Fixes #133

### Summary
- **Dual-path cleanup in `ProjectorBlockEntity.destroyField()`**: Implemented a fallback scan (32-block radius) when inventory/memory is cleared upon explosive destruction (such as those caused by the Ballistix mod missiles).
- **Fixed `BlockPos` type comparison**: Corrected comparison logic during fallback scan using `getProjectorPos()`.
- **Life-cycle guarantee**: Ensured `destroyField()` is called inside `setRemoved()` when the projector block entity is destroyed.
- **Secondary/Deferred cleanup**: Updated `ForceFieldBlockEntity` to inherit from `BaseBlockEntity` and implemented a staggered `tickServer()` validation (modulo-20 `hashCode()`) to clean up orphan/ghost field blocks dynamically without causing TPS drops.

### Testing
- Verified that force field blocks instantly vanish when the projector is blown up by explosives or mined.
- Verified that outer orphan blocks clear gracefully via staggered server ticks.