### PR TITLE
Performance patch (1.21.1)

### DIFF
--- a/src/main/java/dev/su5ed/mffs/mixin/BlockEntityRenderDispatcherMixin.java
+++ b/src/main/java/dev/su5ed/mffs/mixin/BlockEntityRenderDispatcherMixin.java
@@ -1,0 +1,23 @@
+package dev.su5ed.mffs.mixin;
+
+import dev.su5ed.mffs.blockentity.ForceFieldBlockEntity;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BlockEntityRenderDispatcher.class)
+public class BlockEntityRenderDispatcherMixin {
+    @Inject(method = "getRenderer(Lnet/minecraft/world/level/block/entity/BlockEntity;)Lnet/minecraft/client/renderer/blockentity/BlockEntityRenderer;", at = @At("HEAD"), cancellable = true)
+    private <E extends BlockEntity> void getRendererMixin(E blockEntity, CallbackInfoReturnable<BlockEntityRenderer<E>> cir) {
+        if (blockEntity instanceof ForceFieldBlockEntity forceFieldBlockEntity) {
+            if (forceFieldBlockEntity.getCamouflage() == null || !(forceFieldBlockEntity.getCamouflage().getBlock() instanceof EntityBlock)) {
+                cir.setReturnValue(null);
+            }
+        }
+    }
+}

--- a/src/main/java/dev/su5ed/mffs/render/ForceFieldBlockEntityRenderer.java
+++ b/src/main/java/dev/su5ed/mffs/render/ForceFieldBlockEntityRenderer.java
@@ -5,7 +5,9 @@ import dev.su5ed.mffs.blockentity.ForceFieldBlockEntity;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
 
 public class ForceFieldBlockEntityRenderer implements BlockEntityRenderer<ForceFieldBlockEntity> {
 
@@ -17,5 +19,10 @@ public class ForceFieldBlockEntityRenderer implements BlockEntityRenderer<ForceF
         if (camouflage != null) {
             BlockEntityRenderDelegate.INSTANCE.tryRenderDelegate(blockEntity, partialTick, poseStack, bufferSource, packedLight, packedOverlay);
         }
+    }
+
+    @Override
+    public boolean shouldRender(ForceFieldBlockEntity blockEntity, Vec3 cameraPos) {
+        return blockEntity.getCamouflage() != null && blockEntity.getCamouflage().getBlock() instanceof EntityBlock && BlockEntityRenderer.super.shouldRender(blockEntity, cameraPos);
     }
 }

--- a/src/main/resources/mffs.mixins.json
+++ b/src/main/resources/mffs.mixins.json
@@ -10,7 +10,8 @@
       "ExplosionMixin"
   ],
   "client": [
-      "MinecraftMixin"
+      "MinecraftMixin",
+      "BlockEntityRenderDispatcherMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
1.21.1 version of https://github.com/BuiltBrokenModding/MFFS_Classic/pull/141, read the full description there
Pre-Patch:
<img width="3440" height="1351" alt="pre-patch-no-camo-vanilla-rendering-1 21 1" src="https://github.com/user-attachments/assets/05573420-3308-4805-9356-aebf8f64d190" />
Pre-Patch Sodium:
<img width="3440" height="1351" alt="pre-patch-no-camo-sodium-rendering-1 21 1" src="https://github.com/user-attachments/assets/2a8c3496-4dd5-4ed2-9385-77ea334a531f" />
Patched:
<img width="3440" height="1351" alt="patched-no-camo-vanilla-rendering-1 21 1" src="https://github.com/user-attachments/assets/eee6328d-4c9c-4f00-b4f5-b59a2f4ba573" />
Patched Sodium:
<img width="3440" height="1351" alt="patched-no-camo-sodium-rendering-1 21 1" src="https://github.com/user-attachments/assets/be5c99de-524e-4677-bfac-68cf9ef135bc" />
